### PR TITLE
Set terminationMessagePolicy=FallbackToLogsOnError

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -111,7 +111,7 @@ var ResourceBuilder = utils.NewResourceBuilder(commonLabels, operatorLabels)
 // CreateContainer creates container
 func CreateContainer(name, image, verbosity, pullPolicy string) corev1.Container {
 	container := ResourceBuilder.CreateContainer(name, image, pullPolicy)
-	container.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+	container.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 	container.TerminationMessagePath = corev1.TerminationMessagePathDefault
 	container.Args = []string{"-v=" + verbosity}
 	container.SecurityContext = &corev1.SecurityContext{


### PR DESCRIPTION
Apply the best practice
in https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy by setting the `spec.terminationMessagePolicy` field to `FallbackToLogsOnError` in all the pods.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set terminationMessagePolicy=FallbackToLogsOnError to all aaq pods
```
