### PR TITLE
Update builder image to multi-arch tag

### DIFF
--- a/hack/build/config.sh
+++ b/hack/build/config.sh
@@ -25,7 +25,7 @@ CR_NAME=${CR_NAME:-aaq}
 BUILD_ARCHES=${BUILD_ARCHES:-amd64 arm64 s390x}
 
 # update this whenever new builder tag is created
-BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-aaq-bazel-builder:2601181236-218a6f5a}
+BUILDER_IMAGE=${BUILDER_IMAGE:-quay.io/kubevirt/kubevirt-aaq-bazel-builder:2603120913-7cc730d2}
 
 function parseTestOpts() {
     pkgs=""


### PR DESCRIPTION
Update to latest builder image, which is the first multiarch builds.
Follow up for https://github.com/kubevirt/application-aware-quota/pull/166.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the builder image tag to the latest version, which is the first multiarch builder image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
