### PR TITLE
PodUsageFunc: fix calculator error being silently overwritten

### DIFF
--- a/staging/src/kubevirt.io/application-aware-quota-api/libsidecar/sidecar.go
+++ b/staging/src/kubevirt.io/application-aware-quota-api/libsidecar/sidecar.go
@@ -83,7 +83,7 @@ func (s *Server) PodUsageFunc(_ context.Context, request *aaqsidecarevaluate.Pod
 		existingPods = append(existingPods, currPod)
 	}
 
-	rl, match, err := s.sidecarCalculator.PodUsageFunc(podToEvaluate, existingPods)
+	rl, match, calcErr := s.sidecarCalculator.PodUsageFunc(podToEvaluate, existingPods)
 
 	rlData, err := json.Marshal(rl)
 	if err != nil {
@@ -94,9 +94,9 @@ func (s *Server) PodUsageFunc(_ context.Context, request *aaqsidecarevaluate.Pod
 		Match:        match,
 		ResourceList: &aaqsidecarevaluate.ResourceList{ResourceListJson: rlData},
 	}
-	if err != nil {
+	if calcErr != nil {
 		podUsageResponse.Error.Error = true
-		podUsageResponse.Error.ErrorMessage = err.Error()
+		podUsageResponse.Error.ErrorMessage = calcErr.Error()
 	}
 
 	return podUsageResponse, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

In `libsidecar/sidecar.go`, the `PodUsageFunc` method has a variable overwriting bug. The error returned by `s.sidecarCalculator.PodUsageFunc` on line 86 is overwritten by `json.Marshal` on line 88. If the calculator returns an error but `json.Marshal` succeeds, the calculator error is silently dropped and the response is returned with no error, masking a real failure.

This PR renames the calculator error variable to `calcErr` to prevent the overwrite, ensuring it is correctly propagated in the response.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- `go build ./...` — passed
- `go vet ./...` — passed
- `make test` — all 14 test suites passed (181 specs, 0 failures)

**Release note**:
```release-note
None
```