### PR TITLE
Fix deadlock when releasePods fails in aaq-gate-controller

### DIFF
--- a/pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go
+++ b/pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go
@@ -312,6 +312,11 @@ func (ctrl *AaqGateController) execute(ns string) (error, enqueueState) {
 	}
 
 	if len(aaqjqc.Status.PodsInJobQueue) > 0 {
+		err = ctrl.releasePods(aaqjqc.Status.PodsInJobQueue, ns)
+		if err != nil {
+			return err, BackOff
+		}
+
 		aaqjqc.Status.ControllerLock = map[string]bool{}
 		for _, lockName := range locksNames {
 			if lockName == ApplicationAwareClusterResourceQuotaLockName && !ctrl.clusterQuotaEnabled {
@@ -323,11 +328,6 @@ func (ctrl *AaqGateController) execute(ns string) (error, enqueueState) {
 		if err != nil {
 			return err, Immediate
 		}
-	}
-
-	err = ctrl.releasePods(aaqjqc.Status.PodsInJobQueue, ns)
-	if err != nil {
-		return err, Immediate
 	}
 	return nil, Forget
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes a deadlock in the AAQ gate controller where the ControllerLock is persisted to status before `releasePods()` is called. If `releasePods()` fails partway through (e.g., API error updating a pod), the lock remains set but pods retain their scheduling gates. This prevents the ARQ and ACRQ controllers from unlocking since they wait for all pods to have gates removed via `VerifyPodsWithOutSchedulingGates()`, creating a permanent deadlock that requires manual intervention.

The fix moves the `UpdateStatus` call to after successful pod gate removal, and switches the retry strategy from immediate re-enqueue to `AddRateLimited` when `releasePods()` fails to prevent tight retry loops against the API server.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The bug affects the critical path where the gate controller coordinates with ARQ/ACRQ controllers via the `ControllerLock` map. The change reorders operations so the lock is only persisted after successful pod gate removal. The retry logic now uses `AddRateLimited` (rate-limited backoff) instead of immediate re-enqueue when `releasePods()` fails.

Key changes in `pkg/aaq-controller/aaq-gate-controller/aaq-gate-controller.go`:
- Move `releasePods()` call before `UpdateStatus` so the lock is never persisted unless pods are actually released
- Use `BackOff` (maps to `AddRateLimited`) on `releasePods()` failure instead of `Immediate`
- Maintain existing behavior where `releasePods()` returns early on first error (pods already released are safely idempotent on retry)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
