### PR TITLE
Fix collectSidecarSockets hanging on empty directory

### DIFF
--- a/pkg/aaq-controller/aaq-evaluator/evaluator_registry.go
+++ b/pkg/aaq-controller/aaq-evaluator/evaluator_registry.go
@@ -74,30 +74,31 @@ func (aaqe *AaqEvaluatorRegistry) collectSidecarSockets(numberOfRequestedEvaluat
 	timeoutCh := time.After(timeout)
 
 	for uint(len(processedSockets)) < numberOfRequestedEvaluatorsSidecars {
+		select {
+		case <-timeoutCh:
+			return nil, fmt.Errorf("failed to collect all expected evaluators sidecars sockets within given timeout")
+		default:
+		}
+
 		sockets, err := os.ReadDir(aaqe.socketSharedDirectory)
 		if err != nil {
 			return nil, err
 		}
 		for _, socket := range sockets {
-			select {
-			case <-timeoutCh:
-				return nil, fmt.Errorf("Failed to collect all expected evaluators sidecars sockets within given timeout")
-			default:
-				if _, processed := processedSockets[socket.Name()]; processed {
-					continue
-				}
-
-				callBackClient, notReady, err := processSideCarSocket(filepath.Join(aaqe.socketSharedDirectory, socket.Name()))
-				if notReady {
-					log.Log.Info("Sidecar server might not be ready yet, retrying in the next iteration")
-					continue
-				} else if err != nil {
-					log.Log.Reason(err).Infof("Failed to process sidecar socket: %s", socket.Name())
-					return nil, err
-				}
-				sidecarSockets = append(sidecarSockets, callBackClient)
-				processedSockets[socket.Name()] = true
+			if _, processed := processedSockets[socket.Name()]; processed {
+				continue
 			}
+
+			callBackClient, notReady, err := processSideCarSocket(filepath.Join(aaqe.socketSharedDirectory, socket.Name()))
+			if notReady {
+				log.Log.Info("Sidecar server might not be ready yet, retrying in the next iteration")
+				continue
+			} else if err != nil {
+				log.Log.Reason(err).Infof("Failed to process sidecar socket: %s", socket.Name())
+				return nil, err
+			}
+			sidecarSockets = append(sidecarSockets, callBackClient)
+			processedSockets[socket.Name()] = true
 		}
 		time.Sleep(time.Second)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug where collectSidecarSockets hangs indefinitely when the sidecar socket directory is empty. The timeout check was located inside the inner loop that iterates over discovered sockets, so when no sockets existed, the timeout was never evaluated and the function looped forever calling os.ReadDir. This blocked the aaq-controller from completing initialization.

The fix adds a timeout check in the outer loop before the ReadDir call, ensuring the timeout is always respected regardless of whether sockets are present.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The original code only checked the timeout channel inside the `for _, socket := range sockets` loop. When ReadDir returned an empty slice, this loop had zero iterations, so the select statement was never reached. The outer loop would then sleep and retry indefinitely.

The fix adds a timeout select before ReadDir to catch this case. A regression test (TestCollectSidecarSocketsTimeout) verifies the function returns within the expected timeout when given an empty directory.

**Release note**:

```release-note
NONE
```