### PR TITLE
Fix nil pointer dereference in CRD watcher when no active AAQ CR exists

### DIFF
--- a/pkg/aaq-operator/cruft.go
+++ b/pkg/aaq-operator/cruft.go
@@ -19,6 +19,10 @@ func (r *ReconcileAAQ) watchAAQCRD() error {
 			}
 			cr, err := util.GetActiveAAQ(r.client)
 			if err != nil {
+				log.Error(err, "Failed to get active AAQ CR")
+				return nil
+			}
+			if cr == nil {
 				return nil
 			}
 			return []reconcile.Request{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a nil pointer dereference in the CRD watcher (`watchAAQCRD`) that causes the AAQ operator to panic when a CRD update event fires while no active AAQ CR exists. This occurs during AAQ CR deletion cycles (e.g., when HCO disables AAQ). Every other caller of `GetActiveAAQ` in the codebase already guards against the nil return; this aligns the CRD watcher with the established pattern.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`GetActiveAAQ` returns `(nil, nil)` when no active CRs exist. The CRD watcher only checked `err != nil` before dereferencing the pointer at `cruft.go:28`. During AAQ disable/delete flows, the operator panics and crash-loops until restart clears the finalizer, causing HCO functional test timeouts. Confirmed via pod previous logs showing the SIGSEGV stack trace originating from this line.

**Release note**:
```release-note
Fix AAQ operator panic (nil pointer dereference) when CRD update events fire while no active AAQ CR exists, preventing operator crash-loops during CR deletion.
```