### PR TITLE
Skip qemu-user-static registration for s390x

### DIFF
--- a/hack/build/build-push-multiarch-images.sh
+++ b/hack/build/build-push-multiarch-images.sh
@@ -70,8 +70,8 @@ function create_push_multi_arch_manifest() {
     ${AAQ_CRI} manifest push ${insecure_param} "${manifest_name}"
 }
 
-# allow running binaries for mixed-arch builds, but skip s390x-only runs
-if [[ "${BUILD_ARCHES}" != "s390x" ]]; then
+# allow running binaries for cross-arch builds, but skip qemu registration on s390x hosts
+if [[ "${HOST_ARCHITECTURE}" != "s390x" ]]; then
     ${AAQ_CRI} run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
 fi
 

--- a/hack/build/build-push-multiarch-images.sh
+++ b/hack/build/build-push-multiarch-images.sh
@@ -70,8 +70,10 @@ function create_push_multi_arch_manifest() {
     ${AAQ_CRI} manifest push ${insecure_param} "${manifest_name}"
 }
 
-# allow running binary within image with one architecture, running on machine with another architecture
-${AAQ_CRI} run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+# allow running binaries for mixed-arch builds, but skip s390x-only runs
+if [[ "${BUILD_ARCHES}" != "s390x" ]]; then
+    ${AAQ_CRI} run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
+fi
 
 PUSH_TARGETS=(${PUSH_TARGETS:-$CONTROLLER_IMAGE_NAME $AAQ_SERVER_IMAGE_NAME $OPERATOR_IMAGE_NAME})
 


### PR DESCRIPTION
Skip qemu-user-static registration for s390x

**What this PR does / why we need it**:
Skip qemu-user-static registration when BUILD_ARCHES is s390x in the multi-arch image push script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Related context: `kubevirt/project-infra#5361`
**Special notes for your reviewer**:

This keeps qemu-user-static registration for mixed-arch builds, but avoids running it for s390x-only builds.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
