### PR TITLE
Fix cluster quota handler registration

### DIFF
--- a/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller.go
@@ -2,6 +2,7 @@ package aacrq_controller
 
 import (
 	"context"
+	"fmt"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -59,7 +60,7 @@ func NewAacrqController(aaqCli client.AAQClient,
 		AddFunc:    ctrl.addAcrq,
 	})
 	if err != nil {
-		panic("failed to register ApplicationAwareClusterResourceQuota event handler")
+		panic(fmt.Errorf("failed to register ApplicationAwareClusterResourceQuota event handler: %w", err))
 	}
 
 	return &ctrl

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller.go
@@ -2,7 +2,6 @@ package aacrq_controller
 
 import (
 	"context"
-	"fmt"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -60,6 +59,7 @@ func NewAacrqController(aaqCli client.AAQClient,
 		AddFunc:    ctrl.addAcrq,
 	})
 	if err != nil {
+		panic("failed to register ApplicationAwareClusterResourceQuota event handler")
 	}
 
 	return &ctrl
@@ -167,7 +167,7 @@ func (ctrl *AacrqController) Execute() bool {
 
 	err, enqueueState := ctrl.execute(key.(string))
 	if err != nil {
-		log.Log.Infof(fmt.Sprintf("AacrqController: Error with key: %v err: %v", key, err))
+		log.Log.Infof("AacrqController: Error with key: %v err: %v", key, err)
 	}
 	switch enqueueState {
 	case BackOff:

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller_constructor_test.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller_constructor_test.go
@@ -4,27 +4,15 @@ import (
 	"errors"
 	"testing"
 
-	"k8s.io/client-go/tools/cache"
 	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
 )
-
-type erroringSharedIndexInformer struct {
-	testsutils.FakeSharedIndexInformer
-	err error
-}
-
-func (i erroringSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, i.err
-}
 
 func TestNewAacrqControllerPanicsOnAcrqHandlerRegistrationError(t *testing.T) {
 	t.Helper()
 
 	aacrqInformer := testsutils.NewFakeSharedIndexInformer(nil)
-	acrqInformer := erroringSharedIndexInformer{
-		FakeSharedIndexInformer: testsutils.NewFakeSharedIndexInformer(nil),
-		err:                     errors.New("boom"),
-	}
+	acrqInformer := testsutils.NewFakeSharedIndexInformer(nil)
+	acrqInformer.AddEventHandlerErr = errors.New("boom")
 
 	defer func() {
 		if recover() == nil {

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller_constructor_test.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/aacrq-controller/aacrq-controller_constructor_test.go
@@ -1,0 +1,36 @@
+package aacrq_controller
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
+)
+
+type erroringSharedIndexInformer struct {
+	testsutils.FakeSharedIndexInformer
+	err error
+}
+
+func (i erroringSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, i.err
+}
+
+func TestNewAacrqControllerPanicsOnAcrqHandlerRegistrationError(t *testing.T) {
+	t.Helper()
+
+	aacrqInformer := testsutils.NewFakeSharedIndexInformer(nil)
+	acrqInformer := erroringSharedIndexInformer{
+		FakeSharedIndexInformer: testsutils.NewFakeSharedIndexInformer(nil),
+		err:                     errors.New("boom"),
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when acrq informer handler registration fails")
+		}
+	}()
+
+	NewAacrqController(nil, aacrqInformer, acrqInformer, make(chan struct{}))
+}

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller.go
@@ -2,7 +2,6 @@ package crq_controller
 
 import (
 	"context"
-	"fmt"
 	v12 "github.com/openshift/api/quota/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -67,6 +66,7 @@ func NewCRQController(aaqCli client.AAQClient,
 		AddFunc:    ctrl.addAcrq,
 	})
 	if err != nil {
+		panic("failed to register ApplicationAwareClusterResourceQuota event handler")
 	}
 
 	return &ctrl
@@ -154,7 +154,7 @@ func (ctrl *CRQController) Execute() bool {
 
 	err, enqueueState := ctrl.execute(key.(string))
 	if err != nil {
-		log.Log.Infof(fmt.Sprintf("CRQController: Error with key: %v err: %v", key, err))
+		log.Log.Infof("CRQController: Error with key: %v err: %v", key, err)
 	}
 	switch enqueueState {
 	case BackOff:

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller.go
@@ -2,6 +2,7 @@ package crq_controller
 
 import (
 	"context"
+	"fmt"
 	v12 "github.com/openshift/api/quota/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -66,7 +67,7 @@ func NewCRQController(aaqCli client.AAQClient,
 		AddFunc:    ctrl.addAcrq,
 	})
 	if err != nil {
-		panic("failed to register ApplicationAwareClusterResourceQuota event handler")
+		panic(fmt.Errorf("failed to register ApplicationAwareClusterResourceQuota event handler: %w", err))
 	}
 
 	return &ctrl

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller_constructor_test.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller_constructor_test.go
@@ -4,27 +4,15 @@ import (
 	"errors"
 	"testing"
 
-	"k8s.io/client-go/tools/cache"
 	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
 )
-
-type erroringSharedIndexInformer struct {
-	testsutils.FakeSharedIndexInformer
-	err error
-}
-
-func (i erroringSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, i.err
-}
 
 func TestNewCRQControllerPanicsOnAcrqHandlerRegistrationError(t *testing.T) {
 	t.Helper()
 
 	crqInformer := testsutils.NewFakeSharedIndexInformer(nil)
-	acrqInformer := erroringSharedIndexInformer{
-		FakeSharedIndexInformer: testsutils.NewFakeSharedIndexInformer(nil),
-		err:                     errors.New("boom"),
-	}
+	acrqInformer := testsutils.NewFakeSharedIndexInformer(nil)
+	acrqInformer.AddEventHandlerErr = errors.New("boom")
 
 	defer func() {
 		if recover() == nil {

--- a/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller_constructor_test.go
+++ b/pkg/aaq-controller/additional-cluster-quota-controllers/crq-controller/crq-controller_constructor_test.go
@@ -1,0 +1,36 @@
+package crq_controller
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+	testsutils "kubevirt.io/application-aware-quota/pkg/tests-utils"
+)
+
+type erroringSharedIndexInformer struct {
+	testsutils.FakeSharedIndexInformer
+	err error
+}
+
+func (i erroringSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, i.err
+}
+
+func TestNewCRQControllerPanicsOnAcrqHandlerRegistrationError(t *testing.T) {
+	t.Helper()
+
+	crqInformer := testsutils.NewFakeSharedIndexInformer(nil)
+	acrqInformer := erroringSharedIndexInformer{
+		FakeSharedIndexInformer: testsutils.NewFakeSharedIndexInformer(nil),
+		err:                     errors.New("boom"),
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when acrq informer handler registration fails")
+		}
+	}()
+
+	NewCRQController(nil, crqInformer, acrqInformer, make(chan struct{}))
+}

--- a/pkg/tests-utils/fake-informers.go
+++ b/pkg/tests-utils/fake-informers.go
@@ -13,6 +13,7 @@ import (
 type FakeSharedIndexInformer struct {
 	indexer            cache.Indexer
 	InternalGetIndexer func(cache.Indexer) cache.Indexer
+	AddEventHandlerErr error
 }
 
 func (i FakeSharedIndexInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
@@ -53,10 +54,10 @@ func (i FakeSharedIndexInformer) GetIndexer() cache.Indexer {
 
 }
 func (i FakeSharedIndexInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
+	return nil, i.AddEventHandlerErr
 }
 func (i FakeSharedIndexInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
+	return nil, i.AddEventHandlerErr
 }
 func (i FakeSharedIndexInformer) GetStore() cache.Store           { return nil }
 func (i FakeSharedIndexInformer) GetController() cache.Controller { return nil }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fail fast when cluster quota controller event handler registration fails, instead of silently continuing with a partially initialized controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This updates the CRQ and AACRQ controller constructors to stop ignoring informer handler registration errors.
It also adds focused constructor tests for both controllers and fixes adjacent Infof usage in the touched files so the package tests pass.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
